### PR TITLE
fix: sbom flag

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -74,7 +74,7 @@ fi
 SBOM_ARGS=""
 if [[ -n "${OSTORLAB_SBOM_FILES}" ]]; then
   for sbom_file in ${OSTORLAB_SBOM_FILES}; do
-    SBOM_ARGS+="--sbom-file=${sbom_file} "
+    SBOM_ARGS+="--sbom=${sbom_file} "
   done
 fi
 


### PR DESCRIPTION
### Summary

This PR fixes the SBOM flag in the shell script to match the `oxo` CLI.

### Changes

- Replaced `--sbom-file` with `--sbom` in the shell script.

### Reason

The `oxo` CLI uses `--sbom`, not `--sbom-file`.
